### PR TITLE
Set up publish.yml file for CI publishing to gh-pages from main

### DIFF
--- a/web/.github/workflows/publish.yml
+++ b/web/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: main
+
+name: Quarto Publish
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render and Publish
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This file follows the [instructions](https://quarto.org/docs/publishing/github-pages.html#github-action) from the Quarto docs about setting up CI. This Github action should automatically render and publish the site whenever a new commit is pushed to `main`.