### PR TITLE
Patched surface navigation waypoint bug

### DIFF
--- a/E80_Lab_07_surface/E80_Lab_07_surface.ino
+++ b/E80_Lab_07_surface/E80_Lab_07_surface.ino
@@ -73,7 +73,7 @@ void setup() {
 
   int navigateDelay = 0; // how long robot will stay at surface waypoint before continuing (ms)
 
-  const int num_surface_waypoints = 3; // Set to 0 if only doing depth control
+  const int num_surface_waypoints = 3; // Number of ordered pairs of surface waypoints. (e.g., if surface_waypoints is {x0,y0,x1,y1} then num_surface_waypoints is 2.) Set to 0 if only doing depth control 
   double surface_waypoints [] = { 125, -40, 150, -40, 125, -40 };   // listed as x0,y0,x1,y1, ... etc.
   surface_control.init(num_surface_waypoints, surface_waypoints, navigateDelay);
   

--- a/libraries/main/SurfaceControl.cpp
+++ b/libraries/main/SurfaceControl.cpp
@@ -15,7 +15,7 @@ SurfaceControl::SurfaceControl(void)
 void SurfaceControl::init(const int totalWayPoints_in, double * wayPoints_in, int navigateDelay_in) {
   totalWayPoints = totalWayPoints_in;
   // create wayPoints array on the Heap so that it isn't erased once the main Arduino loop starts
-  wayPoints = new double[totalWayPoints];
+  wayPoints = new double[2*totalWayPoints]; // Create a 1-d array to hold the waypoints in the format x0,y0,x1,y1,...
   for (int i=0; i<totalWayPoints; i++) { 
     wayPoints[i] = wayPoints_in[i];
   }

--- a/libraries/main/SurfaceControl.h
+++ b/libraries/main/SurfaceControl.h
@@ -55,7 +55,7 @@ private:
 
   int getWayPoint(int dim);
 
-  const int stateDims = 2;
+  const int stateDims = 2;  // Number of dimensions in the state vector (x,y)
   int currentWayPoint = 0;
   bool gpsAcquired;
   


### PR DESCRIPTION
The waypoint array needs to have 2*N entries for N ordered x, y pairs. The PR fixes the error by making the array the correct length.