### PR TITLE
Fixed the ADC logging bug

### DIFF
--- a/libraries/main/ADCSampler.cpp
+++ b/libraries/main/ADCSampler.cpp
@@ -4,8 +4,8 @@
 extern Printer printer;
 
 ADCSampler::ADCSampler(void) 
-  : DataSource("Current_Sense,A00,A01,A02,A03,A10,A11,A12,A13,A14,A15,A16,A17,A18,A19,A20",
-               "int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int") // from DataSource
+  : DataSource("Current_Sense,A00,A01,A02,A03,A10,A11,A12,A13",
+               "int,int,int,int,int,int,int,int,int") // from DataSource
 {}
 
 void ADCSampler::init(void)


### PR DESCRIPTION
The header in the inf file included pins from the Teensy 3.2 that were no longer used in the Teensy 4.0. This caused an offset in the logged data which meant that the logreader was incorrectly reading data.

Printer would work fine since the actual values in the DataSource were fine, but the error caused an offset in the inf file that would cause Matlab to misread the data file.